### PR TITLE
Remove monotonic? due to deprecation

### DIFF
--- a/lib/pandas/index.rb
+++ b/lib/pandas/index.rb
@@ -2,10 +2,6 @@ require 'pandas' unless defined?(Pandas)
 
 module Pandas
   class Index
-    def monotonic?
-      is_monotonic
-    end
-
     def monotonic_decreasing?
       is_monotonic_decreasing
     end

--- a/lib/pandas/series.rb
+++ b/lib/pandas/series.rb
@@ -17,10 +17,6 @@ module Pandas
       super
     end
 
-    def monotonic?
-      is_monotonic
-    end
-
     def monotonic_decreasing?
       is_monotonic_decreasing
     end

--- a/spec/pandas/index_spec.rb
+++ b/spec/pandas/index_spec.rb
@@ -2,23 +2,6 @@ require 'spec_helper'
 
 module Pandas
   ::RSpec.describe Index do
-    describe '#monotonic?' do
-      specify do
-        idx = Pandas::Index.new([1, 2, 3, 4, 5])
-        expect(idx).to be_monotonic
-      end
-
-      specify do
-        idx = Pandas::Index.new([5, 4, 3, 2, 1])
-        expect(idx).not_to be_monotonic
-      end
-
-      specify do
-        idx = Pandas::Index.new([1, 2, 6, 4, 5])
-        expect(idx).not_to be_monotonic
-      end
-    end
-
     describe '#monotonic_decreasing?' do
       specify do
         idx = Pandas::Index.new([1, 2, 3, 4, 5])

--- a/spec/pandas/series_spec.rb
+++ b/spec/pandas/series_spec.rb
@@ -43,23 +43,6 @@ module Pandas
       end
     end
 
-    describe '#monotonic?' do
-      specify do
-        s = Pandas::Series.new([1, 2, 3, 4, 5])
-        expect(s).to be_monotonic
-      end
-
-      specify do
-        s = Pandas::Series.new([5, 4, 3, 2, 1])
-        expect(s).not_to be_monotonic
-      end
-
-      specify do
-        s = Pandas::Series.new([1, 2, 6, 4, 5])
-        expect(s).not_to be_monotonic
-      end
-    end
-
     describe '#monotonic_decreasing?' do
       specify do
         s = Pandas::Series.new([1, 2, 3, 4, 5])


### PR DESCRIPTION
The instance methods `is_monotonic` in `Series` and `Index` were deprecated on Pandas 1.5.0.
See https://pandas.pydata.org/docs/whatsnew/v1.5.0.html#other-deprecations